### PR TITLE
Add node serialize method

### DIFF
--- a/core/src/nodes/BooleanNode.ts
+++ b/core/src/nodes/BooleanNode.ts
@@ -20,6 +20,12 @@ export const BooleanNode = (): INode<boolean> => {
       }
       return value
     },
+    serialize() {
+      return {
+        type: 'boolean',
+        optional: this.optional() ? true : undefined
+      }
+    },
     hook(hook, path, ...args) {
       return hook.boolean({ node: this}, path, ...args)
     }

--- a/core/src/nodes/ChoiceNode.ts
+++ b/core/src/nodes/ChoiceNode.ts
@@ -51,6 +51,13 @@ export const ChoiceNode = (choices: Choice[], config?: ChoiceNodeConfig): INode<
       }
       return choice.node.validate(path, value, errors, options)
     },
+    serialize() {
+      return {
+        type: 'choice',
+        optional: this.optional() ? true : undefined,
+        cases: choices.reduce((f, c) => ({...f, [c.type]: c.node.serialize()}), {})
+      }
+    },
     hook(hook, path, ...args) {
       return hook.choice({ node: this, choices, config: config ?? {}, switchNode}, path, ...args)
     }

--- a/core/src/nodes/ListNode.ts
+++ b/core/src/nodes/ListNode.ts
@@ -51,6 +51,14 @@ export const ListNode = (children: INode, config?: ListNodeConfig): INode<any[]>
         children.validate(path.push(index), obj, errors, options)
       )
     },
+    serialize() {
+      return {
+        type: 'list',
+        optional: this.optional() ? true : undefined,
+        values: children.serialize(),
+        ...config
+      }
+    },
     hook(hook, path, ...args) {
       return hook.list({ node: this, children, config: config ?? {} }, path, ...args)
     }

--- a/core/src/nodes/MapNode.ts
+++ b/core/src/nodes/MapNode.ts
@@ -54,6 +54,15 @@ export const MapNode = (keys: INode<string>, children: INode, config?: MapNodeCo
     validationOption(path) {
       return config?.validation ?? keys.validationOption(path.push(''))
     },
+    serialize() {
+      return {
+        type: 'map',
+        optional: this.optional() ? true : undefined,
+        keys: keys.serialize(),
+        values: children.serialize(),
+        ...config?.validation
+      }
+    },
     hook(hook, path, ...args) {
       return hook.map({ node: this, keys, children, config: config ?? {} }, path, ...args)
     }

--- a/core/src/nodes/Node.ts
+++ b/core/src/nodes/Node.ts
@@ -117,6 +117,8 @@ export interface INode<T = any> {
    */
   update: (path: ModelPath, value: any) => JsonUpdate[]
 
+  serialize: () => any
+
   [custom: string]: any
 }
 
@@ -134,7 +136,8 @@ export const Base: INode = ({
   validationOption: () => undefined,
   hook(hook, path, ...args) { return hook.base({ node: this }, path, ...args) },
   canUpdate: () => false,
-  update: () => []
+  update: () => [],
+  serialize() { return this.optional() ? { optional: true } : {} },
 })
 
 export const Mod = (node: INode, mods: Partial<INode> | ((node: INode) => Partial<INode>)): INode => ({

--- a/core/src/nodes/NumberNode.ts
+++ b/core/src/nodes/NumberNode.ts
@@ -46,6 +46,13 @@ export const NumberNode = (config?: NumberNodeConfig): INode<number> => {
       }
       return value
     },
+    serialize() {
+      return {
+        type: 'number',
+        optional: this.optional() ? true : undefined,
+        ...config
+      }
+    },
     hook(hook, path, ...args) {
       return hook.number({ node: this, integer, min, max, between, config: config ?? {} }, path, ...args)
     }

--- a/core/src/nodes/ObjectNode.ts
+++ b/core/src/nodes/ObjectNode.ts
@@ -1,7 +1,7 @@
 import { INode, Base } from './Node'
 import { Path, ModelPath, RelativePath, relativePath } from '../model/Path'
 import { Errors } from '../model/Errors'
-import { quoteString } from '../utils'
+import { objMap, quoteString } from '../utils'
 
 export const Switch = Symbol('switch')
 export const Case = Symbol('case')
@@ -131,6 +131,19 @@ export const ObjectNode = (fields: FilteredChildren, config?: ObjectNodeConfig):
         }
       })
       return res
+    },
+    serialize() {
+      return {
+        type: 'object',
+        optional: this.optional() ? true : undefined,
+        properties: objMap(defaultFields, n => n.serialize()),
+        ...(filter ? {
+          dispatch: {
+            path: filter,
+            cases: objMap(cases!, c => objMap(c, n => n.serialize()))
+          }
+        } : {})
+      }
     },
     hook(hook, path, ...args) {
       return hook.object({ node: this, fields: defaultFields, filter, cases, getActiveFields, getChildModelPath }, path, ...args)

--- a/core/src/nodes/Reference.ts
+++ b/core/src/nodes/Reference.ts
@@ -50,6 +50,9 @@ export const Reference = <T>(schemas: Registry<INode>, schema: string): INode<T>
   canUpdate(path: ModelPath, value: any) {
     return schemas.get(schema).canUpdate.bind(this)(path, value)
   },
+  serialize() {
+    return schema
+  },
   update(path: ModelPath, value: any) {
     return schemas.get(schema).update.bind(this)(path, value)
   }

--- a/core/src/nodes/StringNode.ts
+++ b/core/src/nodes/StringNode.ts
@@ -78,6 +78,13 @@ export const StringNode = (collections?: Registry<string[]>, config?: Validation
     validationOption() {
       return isValidator(config) ? config : undefined
     },
+    serialize() {
+      return {
+        type: 'string',
+        optional: this.optional() ? true : undefined,
+        ...config
+      }
+    },
     hook(hook, path, ...args) {
       return hook.string({ node: this, getValues, config }, path, ...args)
     }

--- a/core/src/nodes/SwitchNode.ts
+++ b/core/src/nodes/SwitchNode.ts
@@ -59,6 +59,9 @@ export const SwitchNode = <T>(cases: Case<T>[]): INode<T> => {
       }
       return (matchedCases.length > 0 ? matchedCases[0] : undefined)
     },
+    serialize() {
+      return cases[cases.length - 1].node.serialize()
+    },
     hook(hook, path, ...args) {
       return this.activeCase(path, true)
         .node.hook(hook, path, ...args)

--- a/core/src/utils.ts
+++ b/core/src/utils.ts
@@ -5,3 +5,7 @@ export function escapeString(str: string) {
 export function quoteString(str: string) {
     return `"${escapeString(str)}"`
 }
+
+export function objMap<U, V>(obj: {[k: string]: U}, fn: (v: U) => V): {[k: string]: V} {
+    return Object.keys(obj).reduce((o, k) => ({...o, [k]: fn(obj[k])}), {})
+}


### PR DESCRIPTION
### Usage
```ts
for (const id in schemas['registry']) {
  const schema = schemas.get(id);
  console.log(id, JSON.stringify(schema.serialize(), null, 2));
}
```

### Example
Current 1.17 schemas: <https://gist.github.com/misode/b78d61fb64fd6511e499c09e328cd3fe>

### Todo
- Collect feedback if format is acceptable
- Add workflow to generate serialized schemas
  - In a separate branch, one JSON file for each version
- In the future: find a better way to do some of the stuff that is now done through `SwitchNode` and `enabled`