### PR TITLE
Restructure tsconfigs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,9 +37,11 @@ jobs:
           npm run build
           npm test
 
-      - name: Test Java 1.17
+      - name: Test Java Packages
         run: | 
-          cd java/1.17
-          npm i
-          npm link @mcschema/core
+          cd java
+          cd 1.15 && npm i && npm link @mcschema/core && cd ..
+          cd 1.16 && npm i && npm link @mcschema/core && cd ..
+          cd 1.17 && npm i && npm link @mcschema/core && cd ..
+          cd ..
           npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         
-      - name: Cache Core Node Modules
-        uses: actions/cache@v1
+      - name: Cache Node Modules
+        uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/core/package-lock.json') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+            ${{ runner.os }}-
+        
+      - name: Cache Build Info
+        uses: actions/cache@v2
+        with:
+          path: '**/*.tsbuildinfo'
+          key: ${{ runner.os }}-tsbuildinfo
+          restore-keys: |
+            ${{ runner.os }}-tsbuildinfo-
             ${{ runner.os }}-
 
       - name: Test Core
@@ -27,19 +36,10 @@ jobs:
           sudo npm link
           npm run build
           npm test
-        
-      - name: Cache Java 1.16 Node Modules
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/java/1.16/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-            ${{ runner.os }}-
 
-      - name: Test Java 1.16
+      - name: Test Java 1.17
         run: | 
-          cd java/1.16
+          cd java/1.17
           npm i
           npm link @mcschema/core
           npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib/
+*.tsbuildinfo

--- a/core/package.json
+++ b/core/package.json
@@ -30,6 +30,7 @@
     "access": "public"
   },
   "files": [
-    "lib/**/*"
+    "lib/**/*",
+    "!lib/**/*.tsbuildinfo"
   ]
 }

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,13 +1,7 @@
 {
+  "extends": "../tsconfig-base",
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
-    "declaration": true,
-    "outDir": "lib",
-    "strict": true,
-    "esModuleInterop": true,
-    "downlevelIteration": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "lib"
   },
   "include": [
     "src"

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig-base",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "lib"
   },
   "include": [

--- a/java/1.15/package.json
+++ b/java/1.15/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "files": [
-    "lib/**/*"
+    "lib/**/*",
+    "!lib/**/*.tsbuildinfo"
   ]
 }

--- a/java/1.15/tsconfig.json
+++ b/java/1.15/tsconfig.json
@@ -1,12 +1,7 @@
 {
+  "extends": "../../tsconfig-base",
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
-    "declaration": true,
-    "outDir": "lib",
-    "strict": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "lib"
   },
   "include": [
     "src"

--- a/java/1.15/tsconfig.json
+++ b/java/1.15/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "lib"
   },
   "include": [

--- a/java/1.16/package.json
+++ b/java/1.16/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "files": [
-    "lib/**/*"
+    "lib/**/*",
+    "!lib/**/*.tsbuildinfo"
   ]
 }

--- a/java/1.16/tsconfig.json
+++ b/java/1.16/tsconfig.json
@@ -1,12 +1,7 @@
 {
+  "extends": "../../tsconfig-base",
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
-    "declaration": true,
-    "outDir": "lib",
-    "strict": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "lib"
   },
   "include": [
     "src"

--- a/java/1.16/tsconfig.json
+++ b/java/1.16/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "lib"
   },
   "include": [

--- a/java/1.17/package.json
+++ b/java/1.17/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "files": [
-    "lib/**/*"
+    "lib/**/*",
+    "!lib/**/*.tsbuildinfo"
   ]
 }

--- a/java/1.17/tsconfig.json
+++ b/java/1.17/tsconfig.json
@@ -1,12 +1,7 @@
 {
+  "extends": "../../tsconfig-base",
   "compilerOptions": {
-    "target": "es2018",
-    "module": "commonjs",
-    "declaration": true,
-    "outDir": "lib",
-    "strict": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "lib"
   },
   "include": [
     "src"

--- a/java/1.17/tsconfig.json
+++ b/java/1.17/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig-base",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "lib"
   },
   "include": [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "build": "tsc -b",
+    "watch": "tsc -b -w"
+  }
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "incremental": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+   "files": [],
+   "references": [
+      {
+         "path": "core"
+      },
+      {
+         "path": "java/1.15"
+      },
+      {
+         "path": "java/1.16"
+      },
+      {
+         "path": "java/1.17"
+      }
+   ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
-   "files": [],
-   "references": [
-      {
-         "path": "core"
-      },
-      {
-         "path": "java/1.15"
-      },
-      {
-         "path": "java/1.16"
-      },
-      {
-         "path": "java/1.17"
-      }
-   ]
+  "files": [],
+  "references": [
+    {
+      "path": "core"
+    },
+    {
+      "path": "java/1.15"
+    },
+    {
+      "path": "java/1.16"
+    },
+    {
+      "path": "java/1.17"
+    }
+  ]
 }


### PR DESCRIPTION
- Moved common `compilerOptions` to `tsconfig-base.json`.
- Enabled `incremental` compile.
- Utilized [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) so that we can execute `tsc -b` (or `npm run build`) at the root level of this repo, instead of running `tsc` multiple times in each package (i.e. `lerna run build`). The advantage of this over `lerna run build` is that the `tsc` compiler can skip up-to-date packages automatically.